### PR TITLE
Added fact about GitHub office locations

### DIFF
--- a/facts.sh
+++ b/facts.sh
@@ -7,6 +7,7 @@ facts=(
 	"The state tree of Washington is the Western Hemlock."
 	"All mammals get goosebumps."
 	"Queen Alexandra's Birdwing is the largest butterfly in the world: females can reach wingspans of 28cm (11 inches)."
+    "There is a GitHub office in Bellevue, Washington."
 )
 
 # array to keep track of which facts have been viewed


### PR DESCRIPTION
- Behavior before? Showed various facts until the list is exhausted.
- Behavior after? Showed various facts with a new one about the GitHub office in Bellevue until the list is exhausted.
- How did you trigger? ./facts.sh
- How did you test? Ran through the list of facts multiple times, checked to make sure the no functionality was intact.
- Why did you make the change? The facts lacked info about GitHub.